### PR TITLE
Improve pitaya SEO metadata

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -72,7 +72,25 @@ export default function Layout({ children }) {
   return (
     <div className="bg-white dark:bg-slate-800 font-sans text-gray-800 dark:text-slate-200 transition-colors duration-300">
       <Head>
-        {/* Global meta tags can go here */}
+        <title>Pitaya Dragonfruit Mastery: Expert Guides & Tips for Growing Sweet Success</title>
+        <meta
+          name="description"
+          content="Unlock the secrets to thriving pitaya dragonfruit gardens. Learn planting, care, harvesting, and pest control strategies—plus essential pitaya cultivation tips."
+        />
+        <meta
+          name="keywords"
+          content="pitaya dragonfruit, growing dragonfruit, pitaya cultivation tips, dragonfruit care and maintenance, pitaya farm, pitaya varieties, best soil for pitaya, dragonfruit trellis ideas, pitaya fertilization schedule, organic pitaya farming, how to grow pitaya dragonfruit from cuttings, best climate for pitaya production, pitaya irrigation and watering tips, dragonfruit pest and disease control, pitaya dragonfruit nutritional benefits"
+        />
+        <meta
+          property="og:title"
+          content="Pitaya Dragonfruit Mastery: Expert Guides & Tips for Growing Sweet Success"
+        />
+        <meta
+          property="og:description"
+          content="Unlock the secrets to thriving pitaya dragonfruit gardens. Learn planting, care, harvesting, and pest control strategies—plus essential pitaya cultivation tips."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="Pitaya Dragonfruit Mastery" />
         <link rel="icon" href="/favicon.ico" /> {/* Add a favicon to your public directory */}
       </Head>
 

--- a/content/blog/5-signs-of-overwatering.md
+++ b/content/blog/5-signs-of-overwatering.md
@@ -1,8 +1,8 @@
 ---
-title: "5 Signs You're Overwatering Your Dragon Fruit"
+title: "5 Signs You're Overwatering Your Dragon Fruit Plant"
 date: "2025-08-01"
 author: "Growing Dragon Fruit"
-summary: "Overwatering is the #1 killer of dragon fruit plants. Learn to recognize the subtle signs before it's too late, from yellowing stems to a lack of new growth."
+summary: "Overwatering is the #1 killer of dragon fruit. Learn to recognize the subtle signs before it's too late, from yellowing stems to a lack of new growth."
 featuredImage: "/images/dragonfruit-cutting.jpg"
 relatedPillar: "pests"
 pillarTitle: "Pests & Diseases Guide"

--- a/content/blog/can-i-use-tomato-fertilizer.md
+++ b/content/blog/can-i-use-tomato-fertilizer.md
@@ -1,8 +1,8 @@
 ---
-title: "Can I Use Tomato Fertilizer on My Dragon Fruit?"
+title: "Can I Use Tomato Fertilizer on Dragon Fruit? An NPK Guide"
 date: "2025-06-20"
 author: "Growing Dragon Fruit"
-summary: "You have some tomato food lying around and your dragon fruit looks hungry. Can you use it? We break down the NPK numbers and tell you when it's okay and when it's a bad idea."
+summary: "Have some tomato food lying around? We break down the NPK numbers and explain when it's okay to use tomato fertilizer on your dragon fruit, and when it's a bad idea."
 featuredImage: "/images/tomato-fertilizer.jpg"
 relatedPillar: "fertilizer"
 pillarTitle: "Fertilizing Guide"

--- a/content/blog/pruning-for-shape.md
+++ b/content/blog/pruning-for-shape.md
@@ -1,8 +1,8 @@
 ---
-title: "A Step-by-Step Guide to Your First Pruning"
+title: "A Step-by-Step Guide to Your First Dragon Fruit Pruning"
 date: "2025-06-15"
 author: "Growing Dragon Fruit"
-summary: "Pruning can be intimidating, but it's the key to a productive plant. We'll walk you through the first 'apical cut' to create the perfect umbrella shape for your dragon fruit."
+summary: "Pruning can be intimidating, but it's the key to a productive plant. We'll walk you through the first 'apical cut' to create the perfect umbrella shape."
 featuredImage: "/images/pruning-top.jpg"
 relatedPillar: "trellis-guide"
 pillarTitle: "Trellis & Structure Guide"

--- a/content/guideContent.js
+++ b/content/guideContent.js
@@ -1,6 +1,7 @@
 export const pageContent = {
     'how-to-grow': {
         title: "How to Grow Dragon Fruit: The Complete Start-to-Fruit Guide",
+        description: "Learn everything you need to know to grow dragon fruit at home, from choosing a variety and planting cuttings to pruning, pollination, and harvesting.",
         author: "Growing Dragon Fruit",
         lastUpdated: "June 28, 2025",
         crumbs: [{ label: "How to Grow", path: "how-to-grow" }],
@@ -26,7 +27,8 @@ export const pageContent = {
         cta: { heading: "Ready to Grow?", subheading: "Grab our free care calendar to stay on track!", buttonText: "Get Your Free Care Calendar" }
     },
     'soil-guide': {
-        title: "Best Soil for Dragon Fruit: The Ultimate Guide",
+        title: "Best Soil for Dragon Fruit: The Ultimate DIY Mix Guide",
+        description: "Discover the perfect DIY soil mix for your dragon fruit. Learn about drainage, pH, and the best store-bought options for containers and in-ground planting.",
         author: "Growing Dragon Fruit",
         lastUpdated: "June 28, 2025",
         crumbs: [{ label: "Soil Guide", path: "soil-guide" }],
@@ -44,7 +46,8 @@ export const pageContent = {
         cta: { heading: "Get Your Soil Right!", subheading: "Now that you have the foundation, learn how to feed your plant.", buttonText: "Learn About Fertilizing" }
     },
     'fertilizer': {
-        title: "Fertilizing Dragon Fruit for Growth & Bloom",
+        title: "Fertilizing Dragon Fruit for Growth & Bloom: A Complete Guide",
+        description: "Learn the best fertilizing schedule for dragon fruit. Understand NPK ratios, organic vs. synthetic options, and how to read your plant for deficiencies.",
         author: "Growing Dragon Fruit",
         lastUpdated: "June 28, 2025",
         crumbs: [{ label: "Fertilizer", path: "fertilizer" }],
@@ -73,7 +76,8 @@ export const pageContent = {
         cta: { heading: "Feed Your Way to a Bountiful Harvest!", subheading: "Keep your plant care on schedule with our free calendar.", buttonText: "Download Free Calendar" }
     },
     'trellis-guide': {
-        title: "Dragon Fruit Trellis & Structure Systems",
+        title: "Dragon Fruit Trellis Designs: A DIY & Training Guide",
+        description: "Explore the best trellis designs for dragon fruit, including a DIY plan for the popular post and wheel system. Learn how to train your climbing cactus for maximum fruit production.",
         author: "Growing Dragon Fruit",
         lastUpdated: "June 28, 2025",
         crumbs: [{ label: "Trellis Guide", path: "trellis-guide" }],
@@ -96,7 +100,8 @@ export const pageContent = {
         cta: { heading: "Build the Perfect Support System!", subheading: "A good trellis is a long-term investment in your plant's health.", buttonText: "Explore Dragon Fruit Varieties" }
     },
     'varieties': {
-        title: "Dragon Fruit Varieties & Reviews",
+        title: "Dragon Fruit Varieties & Reviews: From American Beauty to Yellow Dragon",
+        description: "Explore popular dragon fruit varieties like American Beauty, Sugar Dragon, and Yellow Dragon. Learn about their flavor, pollination needs, and which is right for you.",
         author: "Growing Dragon Fruit",
         lastUpdated: "June 28, 2025",
         crumbs: [{ label: "Varieties", path: "varieties" }],
@@ -114,7 +119,8 @@ export const pageContent = {
         cta: { heading: "Found Your Perfect Pitaya?", subheading: "Now learn exactly how to care for it with our complete guides.", buttonText: "Get Your Free Care Calendar" }
     },
     'pests': {
-        title: "Dragon Fruit Pests & Diseases: Identification & Control",
+        title: "Dragon Fruit Pests & Diseases: Identification & Control Guide",
+        description: "Identify and control common dragon fruit pests and diseases. Learn how to prevent root rot, stem canker, and deal with pests like mealybugs and ants.",
         author: "Growing Dragon Fruit",
         lastUpdated: "June 28, 2025",
         crumbs: [{ label: "Pests & Diseases", path: "pests" }],

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -6,13 +6,15 @@ import { useState } from 'react'; // Keep useState for Accordion
 import { Icon, ImageWithFade, SchemaMarkup, AdPlaceholder, VideoPlayer, InfoCard, Breadcrumbs, NavDropdown, ComparisonTable } from '../components';
 import React from 'react'; // Import React for JSX in AccordionItem
 
-const PillarPage = ({ pageData }) => (
+const PillarPage = ({ pageData }) => {
+    const metaDescription = pageData.description || (pageData.content[0]?.paragraphs[0]?.substring(0, 150) + '...');
+    return (
     <div className="animate-fade-in">
         <Head>
             <title>{`${pageData.title} | GrowingDragonFruit.com`}</title>
-            <meta name="description" content={pageData.content[0]?.paragraphs[0]?.substring(0, 150) + '...'} />
+            <meta name="description" content={metaDescription} />
             <meta property="og:title" content={pageData.title} />
-            <meta property="og:description" content={pageData.content[0]?.paragraphs[0]?.substring(0, 150) + '...'} />
+            <meta property="og:description" content={metaDescription} />
             {/* Add more meta tags like og:image, twitter:card, etc. */}
         </Head>
         {/* Hero Section */}
@@ -130,7 +132,8 @@ const PillarPage = ({ pageData }) => (
         )}
 
     </div>
-);
+    );
+};
 
 // Helper component for Accordion (moved from faq.js)
 const AccordionItem = ({ index, title, children }) => {

--- a/pages/about.js
+++ b/pages/about.js
@@ -6,10 +6,16 @@ import { Icon, ImageWithFade, SchemaMarkup, AdPlaceholder, VideoPlayer, InfoCard
 const AboutPage = () => (
     <div className="animate-fade-in">
          <Head>
-            <title>About Us | GrowingDragonFruit.com</title>
-            <meta name="description" content="Learn about our passion for dragon fruit and our mission to help you cultivate thriving plants at home." />
-             <meta property="og:title" content="About Us | GrowingDragonFruit.com" />
-            <meta property="og:description" content="Learn about our passion for dragon fruit and our mission to help you cultivate thriving plants at home." />
+            <title>About Us - Growing Dragon Fruit</title>
+            <meta
+                name="description"
+                content="Learn about the mission and passion behind growingdragonfruit.com, your go-to resource for cultivating pitaya at home."
+            />
+            <meta property="og:title" content="About Us - Growing Dragon Fruit" />
+            <meta
+                property="og:description"
+                content="Learn about the mission and passion behind growingdragonfruit.com, your go-to resource for cultivating pitaya at home."
+            />
              {/* Add more meta tags */}
         </Head>
         <header className="bg-green-50 dark:bg-slate-900 py-20">

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -7,10 +7,19 @@ import Link from 'next/link';
 const BlogIndexPage = ({ posts }) => (
     <div className="animate-fade-in">
         <Head>
-            <title>Dragon Fruit Blog | GrowingDragonFruit.com</title>
-            <meta name="description" content="Our latest tips, tricks, and stories from the world of dragon fruit cultivation." />
-            <meta property="og:title" content="Dragon Fruit Blog | GrowingDragonFruit.com" />
-            <meta property="og:description" content="Our latest tips, tricks, and stories from the world of dragon fruit cultivation." />
+            <title>The Dragon Fruit Blog: Tips, Tricks & Growing Stories</title>
+            <meta
+                name="description"
+                content="Our latest tips, tricks, and stories from the world of dragon fruit cultivation. Find answers to specific questions and follow our gardening journey."
+            />
+            <meta
+                property="og:title"
+                content="The Dragon Fruit Blog: Tips, Tricks & Growing Stories"
+            />
+            <meta
+                property="og:description"
+                content="Our latest tips, tricks, and stories from the world of dragon fruit cultivation. Find answers to specific questions and follow our gardening journey."
+            />
         </Head>
         <header className="bg-green-50 dark:bg-slate-900 py-20">
             <div className="container mx-auto px-4 text-center">

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -6,10 +6,16 @@ import { Icon, ImageWithFade, SchemaMarkup, AdPlaceholder, VideoPlayer, InfoCard
 const ContactPage = () => (
     <div className="animate-fade-in">
         <Head>
-            <title>Contact Us | GrowingDragonFruit.com</title>
-            <meta name="description" content="Get in touch with us! Whether you have a question, feedback, or a success story, we'd love to hear from you." />
-            <meta property="og:title" content="Contact Us | GrowingDragonFruit.com" />
-            <meta property="og:description" content="Get in touch with us! Whether you have a question, feedback, or a success story, we'd love to hear from you." />
+            <title>Contact Us - Growing Dragon Fruit</title>
+            <meta
+                name="description"
+                content="Have a question or feedback? Get in touch with the team at growingdragonfruit.com."
+            />
+            <meta property="og:title" content="Contact Us - Growing Dragon Fruit" />
+            <meta
+                property="og:description"
+                content="Have a question or feedback? Get in touch with the team at growingdragonfruit.com."
+            />
              {/* Add more meta tags */}
         </Head>
         <header className="bg-green-50 dark:bg-slate-900 py-20">

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -96,10 +96,19 @@ const FaqPage = ({ faqs }) => { // Use the faqs prop
     return (
         <div className="animate-fade-in">
             <Head>
-                <title>Frequently Asked Questions | GrowingDragonFruit.com</title>
-                <meta name="description" content="Quick answers to your most common dragon fruit questions." />
-                 <meta property="og:title" content="Frequently Asked Questions | GrowingDragonFruit.com" />
-                <meta property="og:description" content="Quick answers to your most common dragon fruit questions." />
+                <title>FAQs: Your Dragon Fruit Questions Answered</title>
+                <meta
+                    name="description"
+                    content="Find quick answers to the most common questions about growing dragon fruit, from watering and fertilizing to pollination and troubleshooting."
+                />
+                <meta
+                    property="og:title"
+                    content="FAQs: Your Dragon Fruit Questions Answered"
+                />
+                <meta
+                    property="og:description"
+                    content="Find quick answers to the most common questions about growing dragon fruit, from watering and fertilizing to pollination and troubleshooting."
+                />
                  {/* Add more meta tags */}
             </Head>
             <header className="bg-green-50 dark:bg-slate-900 py-20">

--- a/pages/free-calendar.js
+++ b/pages/free-calendar.js
@@ -7,9 +7,15 @@ const CalendarPage = () => (
     <div className="animate-fade-in">
         <Head>
             <title>Free Dragon Fruit Care Calendar | GrowingDragonFruit.com</title>
-            <meta name="description" content="Get your free month-by-month dragon fruit care calendar to ensure abundant harvests." />
+            <meta
+                name="description"
+                content="Download our free, printable month-by-month care calendar to ensure your dragon fruit gets exactly what it needs, when it needs it."
+            />
             <meta property="og:title" content="Free Dragon Fruit Care Calendar | GrowingDragonFruit.com" />
-            <meta property="og:description" content="Get your free month-by-month dragon fruit care calendar to ensure abundant harvests." />
+            <meta
+                property="og:description"
+                content="Download our free, printable month-by-month care calendar to ensure your dragon fruit gets exactly what it needs, when it needs it."
+            />
             {/* Add more meta tags */}
         </Head>
         <div className="bg-green-50 dark:bg-slate-900">

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,11 +6,23 @@ import { Icon, ImageWithFade, SchemaMarkup, AdPlaceholder, VideoPlayer, InfoCard
 const HomePage = () => (
     <div className="animate-fade-in">
         <Head>
-            <title>Grow Dragon Fruit at Home | GrowingDragonFruit.com</title>
-            <meta name="description" content="From Seeds to Sweet Harvests – Master Home-grown Pitaya with our guides on planting, care, soil, fertilizing, trellising, varieties, and pest control." />
-            <meta property="og:title" content="Grow Dragon Fruit at Home | GrowingDragonFruit.com" />
-            <meta property="og:description" content="From Seeds to Sweet Harvests – Master Home-grown Pitaya with our guides on planting, care, soil, fertilizing, trellising, varieties, and pest control." />
-            {/* Add more meta tags like og:image, twitter:card, etc. */}
+            <title>Growing Dragon Fruit: Your Ultimate Guide to Pitaya Cultivation</title>
+            <meta
+                name="description"
+                content="Learn how to grow dragon fruit at home with our comprehensive guides on planting, care, soil, fertilizing, trellising, varieties, and pest control."
+            />
+            <meta
+                property="og:title"
+                content="Growing Dragon Fruit: Your Ultimate Guide to Pitaya Cultivation"
+            />
+            <meta
+                property="og:description"
+                content="Learn how to grow dragon fruit at home with our comprehensive guides on planting, care, soil, fertilizing, trellising, varieties, and pest control."
+            />
+            <meta
+                property="og:image"
+                content="https://images.unsplash.com/photo-1593539138009-50811a2d677d?auto=format&fit=crop&w=1200&h=630&q=80"
+            />
         </Head>
 
         {/* Hero Section */}


### PR DESCRIPTION
## Summary
- add site-wide title, description, keywords and Open Graph tags for pitaya dragonfruit
- specify Open Graph image for homepage
- add page-specific titles and meta descriptions for homepage, pillar guides, blog pages and other site pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2a928e5c8326a413abac50dbef94