### PR TITLE
Render HTML in post summaries and main pages

### DIFF
--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -54,11 +54,14 @@ const PillarPage = ({ pageData }) => (
                             <React.Fragment key={index}>
                                 <div id={`section-${index}`} className="mb-12">
                                      {section.heading && <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-6 pt-4 border-t-4 border-pink-400 dark:border-pink-500">{section.heading}</h2>}
-                                    {section.paragraphs && section.paragraphs.map((p, pIndex) => (
-                                        // Render paragraphs as plain text within <p> tags
-                                        // We'll handle blockquotes and other HTML later with a structured approach
-                                        <p key={pIndex} className="mb-4">{p}</p>
-                                    ))}
+                                    {section.paragraphs &&
+                                        section.paragraphs.map((p, pIndex) => (
+                                            <div
+                                                key={pIndex}
+                                                className="mb-4"
+                                                dangerouslySetInnerHTML={{ __html: p }}
+                                            />
+                                        ))}
                                     {section.table && <ComparisonTable headers={section.table.headers} rows={section.table.rows} />}
                                     {section.image && <ImageWithFade src={section.image} alt={section.heading} className="rounded-lg shadow-md my-8" />}
                                     {section.video && <VideoPlayer videoId={section.video.id} title={section.video.title} />}
@@ -160,9 +163,10 @@ const AccordionItem = ({ index, title, children }) => {
                 className={`grid overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
             >
                 <div className="overflow-hidden">
-                    <div className="p-6 text-gray-800 dark:text-slate-300 leading-relaxed">
-                        {children}
-                    </div>
+                    <div
+                        className="p-6 text-gray-800 dark:text-slate-300 leading-relaxed"
+                        dangerouslySetInnerHTML={{ __html: children }}
+                    />
                 </div>
             </div>
         </div>

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -30,7 +30,10 @@ const BlogIndexPage = ({ posts }) => (
                                 <p className="text-sm text-gray-600 dark:text-slate-400 mb-4">
                                     By <span className="font-semibold text-pink-600 dark:text-pink-400">{post.author}</span> on {post.date}
                                 </p>
-                                <p className="text-gray-800 dark:text-slate-300 mb-6">{post.summary}</p>
+                                <div
+                                    className="text-gray-800 dark:text-slate-300 mb-6"
+                                    dangerouslySetInnerHTML={{ __html: post.summary }}
+                                />
                             </div>
                         </Link>
                     ))}


### PR DESCRIPTION
## Summary
- interpret post summary HTML when listing blog posts
- allow guide pages and FAQs to render embedded HTML markup

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e36e8d194832683b7fb6fc036ceb1