### PR TITLE
Enable class-based dark mode toggle

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -18,14 +18,17 @@ export default function Layout({ children }) {
     return false; // Default to light mode on server
   });
 
-  // Effect to apply/remove 'dark' class to the root element and save preference
+  // Effect to apply/remove theme classes on the root element and save preference
   useEffect(() => {
     if (typeof window !== 'undefined') {
+      const root = document.documentElement;
       if (isDarkMode) {
-        document.documentElement.classList.add('dark');
+        root.classList.add('dark');
+        root.classList.remove('light');
         localStorage.setItem('darkMode', 'true');
       } else {
-        document.documentElement.classList.remove('dark');
+        root.classList.remove('dark');
+        root.classList.add('light');
         localStorage.setItem('darkMode', 'false');
       }
     }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode so the theme switcher can flip between light and dark themes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e90466378832698e1b48a3043e68d