### PR TITLE
Add GA4 tracking tag to document head

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,29 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        {/* Google tag (gtag.js) */}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-5N04S9G0S4"
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-5N04S9G0S4');
+          `}
+        </Script>
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- include GA4 Google tag in global document head to track analytics across all pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688fb8d7207c8326aa980e840beecb1d