### PR TITLE
chore: remove dark mode toggle

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,29 +10,6 @@ export default function Layout({ children }) {
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [mobileGuidesOpen, setMobileGuidesOpen] = useState(false);
-  const [isDarkMode, setIsDarkMode] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const savedMode = localStorage.getItem('darkMode');
-      return savedMode === 'true';
-    }
-    return false; // Default to light mode on server
-  });
-
-  // Effect to apply/remove theme classes on the root element and save preference
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const root = document.documentElement;
-      if (isDarkMode) {
-        root.classList.add('dark');
-        root.classList.remove('light');
-        localStorage.setItem('darkMode', 'true');
-      } else {
-        root.classList.remove('dark');
-        root.classList.add('light');
-        localStorage.setItem('darkMode', 'false');
-      }
-    }
-  }, [isDarkMode]);
 
   // Scroll to top on page change and close mobile menu
   useEffect(() => {
@@ -132,13 +109,6 @@ export default function Layout({ children }) {
                 )
               ))}
             </nav>
-            <button
-              onClick={() => setIsDarkMode(!isDarkMode)}
-              aria-label={`Switch to ${isDarkMode ? 'light' : 'dark'} mode`}
-              className="p-2 rounded-full bg-gray-200 dark:bg-slate-700 text-gray-700 dark:text-yellow-300 hover:bg-gray-300 dark:hover:bg-slate-600 transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-            >
-              {isDarkMode ? <Icon name="sun" className="w-5 h-5" /> : <Icon name="moon" className="w-5 h-5" />}
-            </button>
             <div className="lg:hidden">
               <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}


### PR DESCRIPTION
## Summary
- remove dark/light mode toggle button from site header
- drop dark mode state and related effect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fd054973483269bdefeed8c8fe73d