### PR TITLE
feat: refresh site colors for better contrast

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -50,7 +50,7 @@ export default function Layout({ children }) {
   ];
 
   return (
-    <div className="bg-white dark:bg-slate-800 font-sans text-gray-800 dark:text-slate-200 transition-colors duration-300">
+    <div className="font-sans text-gray-800 dark:text-slate-200 transition-colors duration-300">
       <Head>
         <title>Pitaya Dragonfruit Mastery: Expert Guides & Tips for Growing Sweet Success</title>
         <meta
@@ -92,12 +92,12 @@ export default function Layout({ children }) {
       `}</style>
 
       {/* Header */}
-      <header className="bg-white dark:bg-slate-800/80 dark:backdrop-blur-sm shadow-md sticky top-0 z-50 transition-colors duration-300">
+      <header className="bg-gradient-to-r from-brand-dark to-brand text-white shadow-md sticky top-0 z-50 transition-colors duration-300">
         <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-          <Link href="/#main-content" className="sr-only focus:not-sr-only text-white bg-blue-600 p-2 rounded-lg">Skip to main content</Link>
+          <Link href="/#main-content" className="sr-only focus:not-sr-only text-white bg-brand p-2 rounded-lg focus-visible:ring-2 focus-visible:ring-accent">Skip to main content</Link>
           <Link href="/" className="flex items-center gap-2 cursor-pointer">
-            <Icon name="plant" className="w-8 h-8 text-green-600 dark:text-green-400"/>
-            <span className="text-xl font-bold text-gray-900 dark:text-white">GrowingDragonFruit.com</span>
+            <Icon name="plant" className="w-8 h-8 text-accent"/>
+            <span className="text-xl font-bold text-white">GrowingDragonFruit.com</span>
           </Link>
           <div className="flex items-center gap-4">
             <nav className="hidden lg:flex items-center gap-8">
@@ -105,7 +105,7 @@ export default function Layout({ children }) {
                 link.children ? (
                   <NavDropdown key={link.name} item={link} currentPage={currentPage} />
                 ) : (
-                  <Link key={link.path} href={link.path} className={`pb-1 font-semibold transition-all duration-300 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${currentPage === link.path ? 'text-green-700 dark:text-green-400 border-b-2 border-green-700 dark:border-green-400' : 'text-gray-700 dark:text-slate-300 hover:text-green-700 dark:hover:text-green-400'}`}>{link.name}</Link>
+                  <Link key={link.path} href={link.path} className={`pb-1 font-semibold transition-all duration-300 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${currentPage === link.path ? 'text-accent border-b-2 border-accent' : 'text-white hover:text-accent'}`}>{link.name}</Link>
                 )
               ))}
             </nav>
@@ -115,16 +115,16 @@ export default function Layout({ children }) {
                 aria-label="Open mobile menu"
                 aria-expanded={isMenuOpen}
                 aria-controls="mobile-menu"
-                className="p-2 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                className="p-2 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               >
-                <Icon name={isMenuOpen ? "x" : "menu"} className="w-8 h-8 text-gray-800 dark:text-slate-200"/>
+                <Icon name={isMenuOpen ? "x" : "menu"} className="w-8 h-8 text-white"/>
               </button>
             </div>
           </div>
         </div>
         {/* Mobile Menu */}
         {isMenuOpen && (
-          <div id="mobile-menu" className="lg:hidden bg-white dark:bg-slate-800 shadow-xl absolute top-full left-0 w-full animate-fade-in-down">
+          <div id="mobile-menu" className="lg:hidden bg-brand-dark text-white shadow-xl absolute top-full left-0 w-full animate-fade-in-down">
             <nav className="flex flex-col p-4 space-y-1">
               {navLinks.map(link => {
                 if (link.children) {
@@ -133,18 +133,18 @@ export default function Layout({ children }) {
                       <button
                         onClick={() => setMobileGuidesOpen(!mobileGuidesOpen)}
                         aria-expanded={mobileGuidesOpen}
-                        className="w-full py-3 px-4 text-left rounded-md font-semibold flex justify-between items-center text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        className="w-full py-3 px-4 text-left rounded-md font-semibold flex justify-between items-center hover:bg-brand focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                       >
                         <span>{link.name}</span>
                         <svg className={`w-5 h-5 transition-transform duration-200 ${mobileGuidesOpen ? 'transform rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"></path></svg>
                       </button>
                       {mobileGuidesOpen && (
-                        <div className="flex flex-col space-y-1 pl-4 ml-4 border-l-2 border-gray-200 dark:border-slate-700">
+                        <div className="flex flex-col space-y-1 pl-4 ml-4 border-l-2 border-brand">
                           {link.children.map(child => (
                             <Link
                               key={child.path}
                               href={child.path}
-                              className={`block w-full py-2 px-4 text-left rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${currentPage.startsWith(child.path) ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-400' : 'text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700'}`}
+                              className={`block w-full py-2 px-4 text-left rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${currentPage.startsWith(child.path) ? 'bg-brand-light text-brand-dark' : 'hover:bg-brand text-white'}`}
                             >
                               {child.name}
                             </Link>
@@ -158,7 +158,7 @@ export default function Layout({ children }) {
                   <Link
                     key={link.path}
                     href={link.path}
-                    className={`block py-3 px-4 text-left rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${currentPage === link.path ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-400' : 'text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700'}`}
+                    className={`block py-3 px-4 text-left rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${currentPage === link.path ? 'bg-brand-light text-brand-dark' : 'hover:bg-brand text-white'}`}
                   >
                     {link.name}
                   </Link>
@@ -172,32 +172,32 @@ export default function Layout({ children }) {
       <main id="main-content">{children}</main>
 
       {/* Footer */}
-      <footer className="bg-gray-800 text-white dark:bg-slate-900">
+      <footer className="bg-brand-dark text-white">
         <div className="container mx-auto px-4 py-16">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
             <div>
               <h3 className="text-lg font-bold mb-4">Quick Links</h3>
               <ul className="space-y-2">
                 {footerNavLinks.map(link => (
-                  <li key={link.path}><Link href={link.path} className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">{link.name}</Link></li>
+                  <li key={link.path}><Link href={link.path} className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">{link.name}</Link></li>
                 ))}
               </ul>
             </div>
             <div>
               <h3 className="text-lg font-bold mb-4">Resources</h3>
               <ul className="space-y-2">
-                <li><Link href="/faq" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">FAQs</Link></li>
-                <li><Link href="/free-calendar" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">Free Care Calendar</Link></li>
-                <li><Link href="/blog" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">Blog</Link></li>
+                <li><Link href="/faq" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">FAQs</Link></li>
+                <li><Link href="/free-calendar" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">Free Care Calendar</Link></li>
+                <li><Link href="/blog" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">Blog</Link></li>
               </ul>
             </div>
             <div>
               <h3 className="text-lg font-bold mb-4">Company</h3>
               <ul className="space-y-2">
-                <li><Link href="/about" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">About Us</Link></li>
-                <li><Link href="/contact" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">Contact Us</Link></li>
-                <li><Link href="/privacy-policy" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">Privacy Policy</Link></li>{/* Add privacy policy page */}
-                <li><Link href="/terms-of-service" className="text-gray-400 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">Terms of Service</Link></li>{/* Add terms of service page */}
+                <li><Link href="/about" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">About Us</Link></li>
+                <li><Link href="/contact" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">Contact Us</Link></li>
+                <li><Link href="/privacy-policy" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">Privacy Policy</Link></li>{/* Add privacy policy page */}
+                <li><Link href="/terms-of-service" className="text-gray-200 hover:text-white transition rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent">Terms of Service</Link></li>{/* Add terms of service page */}
               </ul>
             </div>
             <div>

--- a/components/index.js
+++ b/components/index.js
@@ -167,14 +167,14 @@ const InfoCard = ({ icon, title, description, buttonText, linkPath }) => (
 // Breadcrumbs component for navigation context
 const Breadcrumbs = ({ crumbs }) => (
     <nav aria-label="Breadcrumb" className="flex items-center text-sm text-gray-600 dark:text-slate-400 mb-4">
-        <Link href="/" className="hover:text-green-700 dark:hover:text-green-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded">Home</Link>
+        <Link href="/" className="hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded">Home</Link>
         {crumbs.map((crumb, index) => (
             <React.Fragment key={index}>
                 <Icon name="chevronRight" className="w-4 h-4 mx-1" />
                 {index === crumbs.length - 1 ? (
                     <span className="font-semibold text-gray-800 dark:text-white" aria-current="page">{crumb.label}</span>
                 ) : (
-                    <Link href={crumb.path} className=" dark:hover:text-green-400 hover:text-green-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded">{crumb.label}</Link>
+                    <Link href={crumb.path} className="hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded">{crumb.label}</Link>
                 )}
             </React.Fragment>
         ))}
@@ -200,7 +200,7 @@ const NavDropdown = ({ item, currentPage }) => {
                 aria-haspopup="true"
                 aria-expanded={isOpen}
                 onClick={() => setIsOpen(!isOpen)}
-                className={`pb-1 font-semibold transition-all duration-300 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${isChildActive ? 'text-green-600 dark:text-green-400 border-b-2 border-green-600 dark:border-green-400' : 'text-gray-700 dark:text-slate-300 hover:text-green-600 dark:hover:text-green-400'}`}
+                className={`pb-1 font-semibold transition-all duration-300 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${isChildActive ? 'text-accent border-b-2 border-accent' : 'text-white hover:text-accent'}`}
             >
                 {item.name}
                 <svg className={`w-4 h-4 transition-transform duration-200 ${isOpen ? 'transform rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" /></svg>
@@ -210,14 +210,14 @@ const NavDropdown = ({ item, currentPage }) => {
                     role="menu"
                     aria-orientation="vertical"
                     aria-labelledby="guides-menu-button"
-                    className="absolute left-0 top-full mt-0 pt-2 w-56 bg-white dark:bg-slate-800 rounded-b-lg shadow-xl py-2 z-50 animate-fade-in-down"
+                    className="absolute left-0 top-full mt-0 pt-2 w-56 bg-brand-dark text-white rounded-b-lg shadow-xl py-2 z-50 animate-fade-in-down"
                 >
                     {item.children.map(child => (
                         <Link
                             key={child.path}
                             href={child.path}
                             role="menuitem"
-                            className={`w-full text-left block px-4 py-2 text-gray-800 dark:text-slate-200 hover:bg-green-50 dark:hover:bg-green-900/50 hover:text-green-700 dark:hover:text-green-400 transition-colors duration-200 focus:outline-none focus-visible:bg-green-100 dark:focus-visible:bg-green-900 ${currentPage.startsWith(child.path) ? 'font-bold text-green-700 dark:text-green-400' : ''}`}
+                            className={`w-full text-left block px-4 py-2 text-white hover:bg-brand transition-colors duration-200 focus:outline-none focus-visible:bg-brand-light ${currentPage.startsWith(child.path) ? 'font-bold bg-brand-light text-brand-dark' : ''}`}
                         >
                             {child.name}
                         </Link>

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -43,12 +43,12 @@ const BlogPostPage = ({ postData, contentHtml }) => (
       )}
     </Head>
 
-    <header className="bg-green-50 dark:bg-slate-900 py-20">
+    <header className="bg-gradient-to-r from-brand-light to-brand/20 dark:from-brand-dark dark:to-brand py-20">
       <div className="container mx-auto px-4 max-w-4xl">
         <Breadcrumbs crumbs={[{ label: 'Blog', path: '/blog' }, { label: postData.title }]} />
-        <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white">{postData.title}</h1>
-        <p className="mt-4 text-gray-600 dark:text-slate-400">
-          By <span className="font-semibold text-pink-600 dark:text-pink-400">{postData.author}</span> | Published on {postData.date}
+        <h1 className="text-4xl md:text-5xl font-extrabold text-brand-dark dark:text-white">{postData.title}</h1>
+        <p className="mt-4 text-brand-dark/80 dark:text-slate-400">
+          By <span className="font-semibold text-accent">{postData.author}</span> | Published on {postData.date}
         </p>
       </div>
     </header>
@@ -59,14 +59,14 @@ const BlogPostPage = ({ postData, contentHtml }) => (
       </div>
 
       {postData.relatedPillar && (
-        <div className="mt-12 p-6 bg-green-50 dark:bg-green-900/20 rounded-lg border-l-4 border-green-500">
-          <h3 className="text-xl font-bold text-gray-900 dark:text-white">Read the Full Guide</h3>
-          <p className="mt-2 text-gray-800 dark:text-slate-200">
+        <div className="mt-12 p-6 bg-brand-light dark:bg-brand-dark/20 rounded-lg border-l-4 border-brand">
+          <h3 className="text-xl font-bold text-brand-dark dark:text-white">Read the Full Guide</h3>
+          <p className="mt-2 text-brand-dark/80 dark:text-slate-200">
             This article is part of our comprehensive pillar content. For even more detail, check out our full guide.
           </p>
           <Link
             href={`/${postData.relatedPillar}`}
-            className="mt-4 inline-block text-green-700 dark:text-green-400 font-bold hover:text-green-800 dark:hover:text-green-300 transition-colors duration-300 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            className="mt-4 inline-block text-accent font-bold hover:text-brand-dark dark:hover:text-white transition-colors duration-300 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
           >
             Go to {postData.pillarTitle} →
           </Link>

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -21,10 +21,10 @@ const BlogIndexPage = ({ posts }) => (
                 content="Our latest tips, tricks, and stories from the world of dragon fruit cultivation. Find answers to specific questions and follow our gardening journey."
             />
         </Head>
-        <header className="bg-green-50 dark:bg-slate-900 py-20">
+        <header className="bg-gradient-to-r from-brand-light to-brand/20 dark:from-brand-dark dark:to-brand py-20">
             <div className="container mx-auto px-4 text-center">
-                <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white">From the Dragon's Den</h1>
-                <p className="mt-4 text-lg text-gray-800 dark:text-slate-300 max-w-2xl mx-auto">
+                <h1 className="text-4xl md:text-5xl font-extrabold text-brand-dark dark:text-white">From the Dragon's Den</h1>
+                <p className="mt-4 text-lg text-brand-dark/80 dark:text-slate-300 max-w-2xl mx-auto">
                     Our latest tips, tricks, and stories from the world of dragon fruit cultivation.
                 </p>
             </div>
@@ -34,10 +34,10 @@ const BlogIndexPage = ({ posts }) => (
                 <div className="space-y-12">
                     {posts.map(post => (
                         <Link key={post.slug} href={`/blog/${post.slug}`} className="block">
-                            <div className="p-6 bg-gray-50 dark:bg-slate-900/50 rounded-lg border-l-4 border-pink-500 cursor-pointer hover:shadow-lg transition-shadow duration-300">
+                            <div className="p-6 bg-gray-50 dark:bg-slate-900/50 rounded-lg border-l-4 border-brand cursor-pointer hover:shadow-lg transition-shadow duration-300">
                                 <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2">{post.title}</h2>
                                 <p className="text-sm text-gray-600 dark:text-slate-400 mb-4">
-                                    By <span className="font-semibold text-pink-600 dark:text-pink-400">{post.author}</span> on {post.date}
+                                    By <span className="font-semibold text-accent">{post.author}</span> on {post.date}
                                 </p>
                                 <div
                                     className="text-gray-800 dark:text-slate-300 mb-6"

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,15 +28,15 @@ const HomePage = () => (
         {/* Hero Section */}
         <section className="relative text-center text-white py-24 md:py-40 px-4 bg-cover bg-center" style={{ backgroundImage: "url('/images/dragonfruit-hero.jpg')" }}
         >
-            <div className="absolute inset-0 bg-gradient-to-b from-black/60 to-black/30"></div>
+            <div className="absolute inset-0 bg-gradient-to-b from-brand-dark/80 to-brand/40"></div>
             <div className="relative z-10">
                 <h1 className="text-4xl md:text-6xl font-extrabold mb-4 leading-tight text-shadow-md">Grow Dragon Fruit at Home</h1>
                 <h2 className="text-xl md:text-2xl font-light mb-8 max-w-3xl mx-auto text-shadow">From Seeds to Sweet Harvests – Master Home-grown Pitaya</h2>
                 <div className="flex flex-col sm:flex-row justify-center gap-4">
-                    <Link href="/how-to-grow" className="bg-pink-600 text-white font-bold py-3 px-8 rounded-lg hover:bg-pink-700 transition-transform transform hover:scale-105 duration-300 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-pink-400">
+                    <Link href="/how-to-grow" className="bg-brand text-white font-bold py-3 px-8 rounded-lg hover:bg-brand-dark transition-transform transform hover:scale-105 duration-300 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent">
                         Start Growing Now
                     </Link>
-                    <Link href="/free-calendar" className="bg-white text-green-700 font-bold py-3 px-8 rounded-lg hover:bg-gray-100 transition-transform transform hover:scale-105 duration-300 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500">
+                    <Link href="/free-calendar" className="bg-white text-brand-dark font-bold py-3 px-8 rounded-lg hover:bg-gray-100 transition-transform transform hover:scale-105 duration-300 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent">
                         Get Your Free Care Calendar
                     </Link>
                 </div>
@@ -44,11 +44,11 @@ const HomePage = () => (
         </section>
 
         {/* Introduction */}
-        <section className="py-16 md:py-24 bg-gray-50 dark:bg-slate-900">
+        <section className="py-16 md:py-24 bg-brand-light dark:bg-slate-900">
             <div className="container mx-auto px-4 text-center max-w-4xl">
                 <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-6">Why Grow Your Own Dragon Fruit?</h2>
                 <p className="text-lg leading-relaxed text-gray-800 dark:text-slate-300 mb-8">
-                    Growing dragon fruit isn’t just a hobby – it’s a chance to enjoy fresh, pesticide-free fruit and try varieties you’ll never see in stores. Home-grown pitaya also delivers high levels of vitamin C, fiber, magnesium and antioxidants. With <Link href="/soil-guide" className="font-bold text-green-600 dark:text-green-400 hover:underline">the right soil</Link>, sunlight and support, you’ll harvest fruit in 1–3 years when starting from a <Link href="/how-to-grow" className="font-bold text-green-600 dark:text-green-400 hover:underline">cutting</Link>.
+                    Growing dragon fruit isn’t just a hobby – it’s a chance to enjoy fresh, pesticide-free fruit and try varieties you’ll never see in stores. Home-grown pitaya also delivers high levels of vitamin C, fiber, magnesium and antioxidants. With <Link href="/soil-guide" className="font-bold text-accent hover:underline">the right soil</Link>, sunlight and support, you’ll harvest fruit in 1–3 years when starting from a <Link href="/how-to-grow" className="font-bold text-accent hover:underline">cutting</Link>.
                 </p>
                 <ImageWithFade src="https://images.unsplash.com/photo-1613149437142-4712a7638b93?q=80&w=2832&auto=format&fit=crop" alt="Collage of dragon fruit varieties" className="rounded-xl shadow-2xl mx-auto"/>
             </div>
@@ -59,7 +59,7 @@ const HomePage = () => (
             <div className="container mx-auto px-4">
                 <div className="text-center mb-12">
                     <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">Start Your Dragon Fruit Journey</h2>
-                    <p className="text-lg leading-relaxed text-gray-800 dark:text-slate-300 max-w-3xl mx-auto">We’ve created step-by-step guides covering every stage of the process – from <Link href="/varieties" className="font-bold text-green-600 dark:text-green-400 hover:underline">choosing a self-fertile variety</Link> and <Link href="/soil-guide" className="font-bold text-green-600 dark:text-green-400 hover:underline">mixing the perfect soil</Link> to <Link href="/how-to-grow" className="font-bold text-green-600 dark:text-green-400 hover:underline">pruning</Link>, pollination and harvesting. Each guide is comprehensive yet easy to follow.</p>
+                    <p className="text-lg leading-relaxed text-gray-800 dark:text-slate-300 max-w-3xl mx-auto">We’ve created step-by-step guides covering every stage of the process – from <Link href="/varieties" className="font-bold text-accent hover:underline">choosing a self-fertile variety</Link> and <Link href="/soil-guide" className="font-bold text-accent hover:underline">mixing the perfect soil</Link> to <Link href="/how-to-grow" className="font-bold text-accent hover:underline">pruning</Link>, pollination and harvesting. Each guide is comprehensive yet easy to follow.</p>
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <InfoCard icon="plant" title="How to Grow Dragon Fruit" description="Learn everything from planting cuttings and seeds to pollination and harvesting." buttonText="Explore Guide" linkPath="/how-to-grow" />
@@ -80,12 +80,12 @@ const HomePage = () => (
         </section>
 
         {/* Lead Magnet Callout */}
-        <section className="bg-green-50 dark:bg-green-900/20 py-16 md:py-24">
+        <section className="bg-brand-light dark:bg-brand-dark/20 py-16 md:py-24">
             <div className="container mx-auto px-4 flex flex-col md:flex-row items-center gap-8 md:gap-12">
                 <div className="md:w-1/2 text-center md:text-left">
                     <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">Get Your Free Dragon Fruit Care Calendar</h2>
                     <p className="text-lg leading-relaxed text-gray-800 dark:text-slate-300 mb-6">Never miss an important task. Download our month-by-month checklist that covers watering, fertilizing and pruning for every season. Print it or save it to your phone.</p>
-                    <Link href="/free-calendar" className="bg-pink-600 text-white font-bold py-3 px-8 rounded-lg hover:bg-pink-700 transition-transform transform hover:scale-105 duration-300 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-pink-400">
+                    <Link href="/free-calendar" className="bg-brand text-white font-bold py-3 px-8 rounded-lg hover:bg-brand-dark transition-transform transform hover:scale-105 duration-300 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent">
                         Download Your Free Calendar
                     </Link>
                 </div>
@@ -100,9 +100,9 @@ const HomePage = () => (
             <div className="container mx-auto px-4 text-center max-w-3xl">
                 <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">A Community of Pitaya Enthusiasts</h2>
                 <p className="text-lg leading-relaxed text-gray-800 dark:text-slate-300 mb-8">
-                    We’re hobby gardeners turned dragon fruit fanatics. After trial and error with <Link href="/blog/5-signs-of-overwatering" className="font-bold text-green-600 dark:text-green-400 hover:underline">overwatering</Link>, failed trellises and slow-growing seedlings, we documented what works. Now we share research-backed guidance so you can avoid the mistakes and enjoy a <Link href="/how-to-grow" className="font-bold text-green-600 dark:text-green-400 hover:underline">thriving plant</Link>.
+                    We’re hobby gardeners turned dragon fruit fanatics. After trial and error with <Link href="/blog/5-signs-of-overwatering" className="font-bold text-accent hover:underline">overwatering</Link>, failed trellises and slow-growing seedlings, we documented what works. Now we share research-backed guidance so you can avoid the mistakes and enjoy a <Link href="/how-to-grow" className="font-bold text-accent hover:underline">thriving plant</Link>.
                 </p>
-                <Link href="/about" className="text-green-700 dark:text-green-400 font-bold hover:text-green-800 dark:hover:text-green-300 transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded px-2">
+                <Link href="/about" className="text-accent font-bold hover:text-accent/80 transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent rounded px-2">
                     Learn More About Us →
                 </Link>
             </div>

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,4 +1,10 @@
 @import "tailwindcss";
 
+@layer base {
+  body {
+    @apply bg-gray-50 text-gray-900 dark:bg-slate-900 dark:text-slate-100 font-sans;
+  }
+}
+
 /* Add any other global styles here */
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,19 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          light: '#FBCFE8',
+          DEFAULT: '#BE185D',
+          dark: '#831843',
+        },
+        accent: '#F59E0B',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- introduce brand and accent palette in Tailwind and global styles for higher contrast
- restyle navigation, mobile menu, and footer with new gradient and focus colors
- update hero, blog, and callout sections to use refreshed colors and accessible rings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe30f79608326ad1d22766d75f239