### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -6,11 +6,13 @@ const PrivacyPolicyPage = () => (
             <title>Privacy Policy - Growing Dragon Fruit</title>
             <meta
                 name="description"
-                content="Read the privacy policy for GrowingDragonFruit.com to understand how we collect, use, and protect your information."/>
+                content="Learn how GrowingDragonFruit.com collects, uses, and protects personal information."
+            />
             <meta property="og:title" content="Privacy Policy - Growing Dragon Fruit" />
             <meta
                 property="og:description"
-                content="Read the privacy policy for GrowingDragonFruit.com to understand how we collect, use, and protect your information."/>
+                content="Learn how GrowingDragonFruit.com collects, uses, and protects personal information."
+            />
         </Head>
         <header className="bg-green-50 dark:bg-slate-900 py-20">
             <div className="container mx-auto px-4 text-center">
@@ -19,21 +21,68 @@ const PrivacyPolicyPage = () => (
         </header>
         <div className="py-16 md:py-24 bg-white dark:bg-slate-800">
             <div className="container mx-auto px-4 max-w-4xl prose lg:prose-xl leading-relaxed text-gray-800 dark:text-slate-200">
-                <p>Your privacy is important to us. This policy explains what information we collect when you use GrowingDragonFruit.com, how we use it, and the choices you have about it.</p>
+                <p>Last Updated: August 3, 2025</p>
+                <p>This Privacy Policy document contains types of information that is collected and recorded by GrowingDragonFruit.com and how we use it. If you have additional questions or require more information about our Privacy Policy, do not hesitate to contact us.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">General Data Protection Regulation (GDPR)</h2>
+                <p>We are a Data Controller of your information. GrowingDragonFruit.com&#39;s legal basis for collecting and using the personal information described in this Privacy Policy depends on the Personal Information we collect and the specific context in which we collect the information:</p>
+                <ul>
+                    <li>GrowingDragonFruit.com needs to perform a contract with you</li>
+                    <li>You have given GrowingDragonFruit.com permission to do so</li>
+                    <li>Processing your personal information is in GrowingDragonFruit.com legitimate interests</li>
+                    <li>GrowingDragonFruit.com needs to comply with the law</li>
+                </ul>
+                <p>GrowingDragonFruit.com will retain your personal information only for as long as is necessary for the purposes set out in this Privacy Policy. We will retain and use your information to the extent necessary to comply with our legal obligations, resolve disputes, and enforce our policies.</p>
+                <p>If you are a resident of the European Economic Area (EEA), you have certain data protection rights. If you wish to be informed what Personal Information we hold about you and if you want it to be removed from our systems, please contact us.</p>
+                <p>In certain circumstances, you have the following data protection rights:</p>
+                <ul>
+                    <li>The right to access, update or to delete the information we have on you.</li>
+                    <li>The right of rectification.</li>
+                    <li>The right to object.</li>
+                    <li>The right of restriction.</li>
+                    <li>The right to data portability.</li>
+                    <li>The right to withdraw consent.</li>
+                </ul>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Log Files</h2>
+                <p>GrowingDragonFruit.com follows a standard procedure of using log files. These files log visitors when they visit websites. All hosting companies do this and a part of hosting services&#39; analytics. The information collected by log files include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, and possibly the number of clicks. These are not linked to any information that is personally identifiable. The purpose of the information is for analyzing trends, administering the site, tracking users&#39; movement on the website, and gathering demographic information.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Cookies and Web Beacons</h2>
+                <p>Like any other website, GrowingDragonFruit.com uses cookies. These cookies are used to store information including visitors&#39; preferences, and the pages on the website that the visitor accessed or visited. The information is used to optimize the users&#39; experience by customizing our web page content based on visitors&#39; browser type and/or other information.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Google DoubleClick DART Cookie</h2>
+                <p>Google is one of a third-party vendor on our site. It also uses cookies, known as DART cookies, to serve ads to our site visitors based upon their visit to www.website.com and other sites on the internet. However, visitors may choose to decline the use of DART cookies by visiting the Google ad and content network Privacy Policy at the following URL – <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer">https://policies.google.com/technologies/ads</a></p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Our Advertising Partners</h2>
+                <p>Some of advertisers on our site may use cookies and web beacons. Our advertising partners are listed below. Each of our advertising partners has their own Privacy Policy for their policies on user data. For easier access, we hyperlinked to their Privacy Policies below.</p>
+                <ul>
+                    <li><a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer">Google</a></li>
+                </ul>
+
                 <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Information We Collect</h2>
-                <p>We collect information that you voluntarily provide, such as your email address when you contact us. We also gather anonymous data about how visitors use our site through analytics tools to help us improve our content.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">How We Use Information</h2>
-                <p>Information is used to respond to inquiries, provide requested resources, and enhance our website. We do not sell or share your personal information with third parties except as required by law or when necessary to provide services.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Cookies</h2>
-                <p>Cookies are small files stored on your device. We use cookies to understand site usage and improve the user experience. You can disable cookies in your browser settings, though some features may not function properly.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Data Security</h2>
-                <p>We take reasonable measures to protect your information from unauthorized access. However, no method of transmission or storage is completely secure, so we cannot guarantee absolute security.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Your Choices</h2>
-                <p>You may request that we delete personal information we hold about you. To exercise this right or ask questions about this policy, contact us at any time.</p>
-                <p className="mt-16">This policy may be updated occasionally. Continued use of our site signifies acceptance of any changes.</p>
+                <h3>Contact &amp; Email Forms</h3>
+                <p>When you use our contact form or sign up for our free calendar, you may be asked to provide your name and email address. This information is used solely for the purpose of responding to your inquiries or delivering the content you requested (such as the calendar and related informational emails). We will not sell or share your personal information with third parties. You may opt-out of our email list at any time by clicking the &quot;unsubscribe&quot; link in any email you receive from us.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Third Party Privacy Policies</h2>
+                <p>GrowingDragonFruit.com&#39;s Privacy Policy does not apply to other advertisers or websites. Thus, we are advising you to consult the respective Privacy Policies of these third-party ad servers for more detailed information. It may include their practices and instructions about how to opt-out of certain options.</p>
+                <p>You can choose to disable cookies through your individual browser options. To know more detailed information about cookie management with specific web browsers, it can be found at the browsers&#39; respective websites.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Children&#39;s Information</h2>
+                <p>Another part of our priority is adding protection for children while using the internet. We encourage parents and guardians to observe, participate in, and/or monitor and guide their online activity.</p>
+                <p>GrowingDragonFruit.com does not knowingly collect any Personal Identifiable Information from children under the age of 13. If you think that your child provided this kind of information on our website, we strongly encourage you to contact us immediately and we will do our best efforts to promptly remove such information from our records.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Online Privacy Policy Only</h2>
+                <p>Our Privacy Policy applies only to our online activities and is valid for visitors to our website with regards to the information that they shared and/or collect in GrowingDragonFruit.com. This policy is not applicable to any information collected offline or via channels other than this website.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Consent</h2>
+                <p>By using our website, you hereby consent to our Privacy Policy and agree to its terms.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Contact Us</h2>
+                <p>If you have any questions about this Privacy Policy, you can contact us at: <a href="mailto:info@growingdragonfruit.com">info@growingdragonfruit.com</a></p>
             </div>
         </div>
     </div>
 );
 
 export default PrivacyPolicyPage;
+

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -53,6 +53,11 @@ const PrivacyPolicyPage = () => (
                 <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Google DoubleClick DART Cookie</h2>
                 <p>Google is one of a third-party vendor on our site. It also uses cookies, known as DART cookies, to serve ads to our site visitors based upon their visit to www.website.com and other sites on the internet. However, visitors may choose to decline the use of DART cookies by visiting the Google ad and content network Privacy Policy at the following URL – <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer">https://policies.google.com/technologies/ads</a></p>
 
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Google Analytics</h2>
+                <p>We use Google Analytics to track and report website traffic. Google uses the data collected to track and monitor the use of our Service. This data is shared with other Google services. Google may use the collected data to contextualize and personalize the ads of its own advertising network.</p>
+                <p>You can opt-out of having made your activity on the Service available to Google Analytics by installing the Google Analytics opt-out browser add-on. The add-on prevents the Google Analytics JavaScript (ga.js, analytics.js, and dc.js) from sharing information with Google Analytics about visits activity.</p>
+                <p>For more information on the privacy practices of Google, please visit the Google Privacy & Terms web page: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">https://policies.google.com/privacy</a></p>
+
                 <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Our Advertising Partners</h2>
                 <p>Some of advertisers on our site may use cookies and web beacons. Our advertising partners are listed below. Each of our advertising partners has their own Privacy Policy for their policies on user data. For easier access, we hyperlinked to their Privacy Policies below.</p>
                 <ul>

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -1,0 +1,39 @@
+import Head from 'next/head';
+
+const PrivacyPolicyPage = () => (
+    <div className="animate-fade-in">
+        <Head>
+            <title>Privacy Policy - Growing Dragon Fruit</title>
+            <meta
+                name="description"
+                content="Read the privacy policy for GrowingDragonFruit.com to understand how we collect, use, and protect your information."/>
+            <meta property="og:title" content="Privacy Policy - Growing Dragon Fruit" />
+            <meta
+                property="og:description"
+                content="Read the privacy policy for GrowingDragonFruit.com to understand how we collect, use, and protect your information."/>
+        </Head>
+        <header className="bg-green-50 dark:bg-slate-900 py-20">
+            <div className="container mx-auto px-4 text-center">
+                <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white">Privacy Policy</h1>
+            </div>
+        </header>
+        <div className="py-16 md:py-24 bg-white dark:bg-slate-800">
+            <div className="container mx-auto px-4 max-w-4xl prose lg:prose-xl leading-relaxed text-gray-800 dark:text-slate-200">
+                <p>Your privacy is important to us. This policy explains what information we collect when you use GrowingDragonFruit.com, how we use it, and the choices you have about it.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Information We Collect</h2>
+                <p>We collect information that you voluntarily provide, such as your email address when you contact us. We also gather anonymous data about how visitors use our site through analytics tools to help us improve our content.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">How We Use Information</h2>
+                <p>Information is used to respond to inquiries, provide requested resources, and enhance our website. We do not sell or share your personal information with third parties except as required by law or when necessary to provide services.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Cookies</h2>
+                <p>Cookies are small files stored on your device. We use cookies to understand site usage and improve the user experience. You can disable cookies in your browser settings, though some features may not function properly.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Data Security</h2>
+                <p>We take reasonable measures to protect your information from unauthorized access. However, no method of transmission or storage is completely secure, so we cannot guarantee absolute security.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Your Choices</h2>
+                <p>You may request that we delete personal information we hold about you. To exercise this right or ask questions about this policy, contact us at any time.</p>
+                <p className="mt-16">This policy may be updated occasionally. Continued use of our site signifies acceptance of any changes.</p>
+            </div>
+        </div>
+    </div>
+);
+
+export default PrivacyPolicyPage;

--- a/pages/terms-of-service.js
+++ b/pages/terms-of-service.js
@@ -19,18 +19,43 @@ const TermsOfServicePage = () => (
         </header>
         <div className="py-16 md:py-24 bg-white dark:bg-slate-800">
             <div className="container mx-auto px-4 max-w-4xl prose lg:prose-xl leading-relaxed text-gray-800 dark:text-slate-200">
-                <p>By accessing or using GrowingDragonFruit.com, you agree to these terms. If you do not agree, please discontinue use of the site.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Use of Content</h2>
-                <p>The content on this website is for informational purposes only. You may use the information for personal, non-commercial use. Reproduction, distribution, or modification without permission is prohibited.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">No Warranties</h2>
-                <p>All information is provided "as is" without warranties of any kind. We do not guarantee accuracy, completeness, or suitability for any purpose.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Limitation of Liability</h2>
-                <p>GrowingDragonFruit.com and its authors are not liable for any damages or losses resulting from the use of the site or reliance on its content.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">External Links</h2>
-                <p>This site may contain links to third-party websites. We are not responsible for the content or practices of those sites and provide these links for convenience only.</p>
-                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Changes to These Terms</h2>
-                <p>We may update these terms from time to time. Continued use of the site after changes are posted constitutes acceptance of the revised terms.</p>
-                <p className="mt-16">If you have questions about these terms, please contact us.</p>
+                <p>Last Updated: August 3, 2025</p>
+                <p>Welcome to GrowingDragonFruit.com. By accessing or using our website, you agree to be bound by these Terms of Service and our Privacy Policy.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">1. Terms</h2>
+                <p>By accessing this website, you are agreeing to be bound by these website Terms and Conditions of Use, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trade mark law.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">2. Use License</h2>
+                <p>Permission is granted to temporarily download one copy of the materials (information or software) on GrowingDragonFruit.com's website for personal, non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under this license you may not:</p>
+                <ul>
+                    <li>modify or copy the materials;</li>
+                    <li>use the materials for any commercial purpose, or for any public display (commercial or non-commercial);</li>
+                    <li>attempt to decompile or reverse engineer any software contained on GrowingDragonFruit.com's website;</li>
+                    <li>remove any copyright or other proprietary notations from the materials; or</li>
+                    <li>transfer the materials to another person or "mirror" the materials on any other server.</li>
+                </ul>
+                <p>This license shall automatically terminate if you violate any of these restrictions and may be terminated by GrowingDragonFruit.com at any time. Upon terminating your viewing of these materials or upon the termination of this license, you must destroy any downloaded materials in your possession whether in electronic or printed format.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">3. Disclaimer</h2>
+                <p>The materials on GrowingDragonFruit.com's website are provided "as is". GrowingDragonFruit.com makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties, including without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights. Further, GrowingDragonFruit.com does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its Internet website or otherwise relating to such materials or on any sites linked to this site.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">4. Limitations</h2>
+                <p>In no event shall GrowingDragonFruit.com or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption,) arising out of the use or inability to use the materials on GrowingDragonFruit.com's Internet site, even if GrowingDragonFruit.com or a GrowingDragonFruit.com authorized representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">5. Revisions and Errata</h2>
+                <p>The materials appearing on GrowingDragonFruit.com's website could include technical, typographical, or photographic errors. GrowingDragonFruit.com does not warrant that any of the materials on its website are accurate, complete, or current. GrowingDragonFruit.com may make changes to the materials contained on its website at any time without notice. GrowingDragonFruit.com does not, however, make any commitment to update the materials.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">6. Links</h2>
+                <p>GrowingDragonFruit.com has not reviewed all of the sites linked to its Internet website and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by GrowingDragonFruit.com of the site. Use of any such linked website is at the user's own risk.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">7. Site Terms of Use Modifications</h2>
+                <p>GrowingDragonFruit.com may revise these terms of use for its website at any time without notice. By using this website you are agreeing to be bound by the then current version of these Terms and Conditions of Use.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">8. Governing Law</h2>
+                <p>Any claim relating to GrowingDragonFruit.com's website shall be governed by the laws of the State of [Your State] without regard to its conflict of law provisions.</p>
+
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">9. Contact Us</h2>
+                <p>If you have any questions about these Terms, please contact us at: <a href="mailto:info@growingdragonfruit.com">info@growingdragonfruit.com</a></p>
             </div>
         </div>
     </div>

--- a/pages/terms-of-service.js
+++ b/pages/terms-of-service.js
@@ -1,0 +1,39 @@
+import Head from 'next/head';
+
+const TermsOfServicePage = () => (
+    <div className="animate-fade-in">
+        <Head>
+            <title>Terms of Service - Growing Dragon Fruit</title>
+            <meta
+                name="description"
+                content="Review the terms and conditions for using GrowingDragonFruit.com."/>
+            <meta property="og:title" content="Terms of Service - Growing Dragon Fruit" />
+            <meta
+                property="og:description"
+                content="Review the terms and conditions for using GrowingDragonFruit.com."/>
+        </Head>
+        <header className="bg-green-50 dark:bg-slate-900 py-20">
+            <div className="container mx-auto px-4 text-center">
+                <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white">Terms of Service</h1>
+            </div>
+        </header>
+        <div className="py-16 md:py-24 bg-white dark:bg-slate-800">
+            <div className="container mx-auto px-4 max-w-4xl prose lg:prose-xl leading-relaxed text-gray-800 dark:text-slate-200">
+                <p>By accessing or using GrowingDragonFruit.com, you agree to these terms. If you do not agree, please discontinue use of the site.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Use of Content</h2>
+                <p>The content on this website is for informational purposes only. You may use the information for personal, non-commercial use. Reproduction, distribution, or modification without permission is prohibited.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">No Warranties</h2>
+                <p>All information is provided "as is" without warranties of any kind. We do not guarantee accuracy, completeness, or suitability for any purpose.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Limitation of Liability</h2>
+                <p>GrowingDragonFruit.com and its authors are not liable for any damages or losses resulting from the use of the site or reliance on its content.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">External Links</h2>
+                <p>This site may contain links to third-party websites. We are not responsible for the content or practices of those sites and provide these links for convenience only.</p>
+                <h2 className="font-bold text-3xl text-gray-900 dark:text-white mt-16">Changes to These Terms</h2>
+                <p>We may update these terms from time to time. Continued use of the site after changes are posted constitutes acceptance of the revised terms.</p>
+                <p className="mt-16">If you have questions about these terms, please contact us.</p>
+            </div>
+        </div>
+    </div>
+);
+
+export default TermsOfServicePage;


### PR DESCRIPTION
## Summary
- add `/privacy-policy` page describing information collection, usage, cookies, security, and user choices
- add `/terms-of-service` page outlining content usage, warranties, liability, external links, and change policy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890024a175883269ecb295e15079e6d