### PR TITLE
Fix comparison table cells not rendering

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -243,10 +243,13 @@ const ComparisonTable = ({ headers, rows }) => (
             {rows.map((row, rowIndex) => (
                 <tr key={rowIndex} className="even:bg-gray-50 dark:even:bg-slate-900/50">
                     {row.map((cell, cellIndex) => (
-                        <td key={cellIndex} className="p-4 border-t border-gray-200 dark:border-slate-700" />
-                    ))
-
-                    }
+                        <td
+                            key={cellIndex}
+                            className="p-4 border-t border-gray-200 dark:border-slate-700"
+                        >
+                            {cell}
+                        </td>
+                    ))}
                 </tr>
             ))}
             </tbody>


### PR DESCRIPTION
## Summary
- Render table cell contents in `ComparisonTable` so data appears in front-end tables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890277a9f048326a4c204a425c43aa3